### PR TITLE
Model relations introspection is permission-aware

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Features
 --------
 
 * Generic action to enable export data from Admin.
-* Automatic traversal of model relations.
+* Automatic permission-aware traversal of model relations.
 * Selection of fields to export.
 * Can export to XSLx, CSV and HTML.
 

--- a/export_action/introspection.py
+++ b/export_action/introspection.py
@@ -139,7 +139,7 @@ def get_fields(model_class, field_name='', path=''):
     }
 
 
-def get_related_fields(model_class, field_name, path=""):
+def get_related_fields(model_class, field_name, path="", user=None):
     """ Get fields for a given model """
     if field_name:
         field, model, direct, m2m = _get_field_by_name(model_class, field_name)
@@ -161,7 +161,9 @@ def get_related_fields(model_class, field_name, path=""):
     else:
         new_model = model_class
 
-    new_fields = get_relation_fields_from_model(new_model)
+    from export_action.report import _can_change_or_view
+    new_fields = [field for field in get_relation_fields_from_model(new_model)
+                  if user and _can_change_or_view(field.model, user)]
     model_ct = ContentType.objects.get_for_model(new_model)
 
     return (new_fields, model_ct, path)

--- a/export_action/views.py
+++ b/export_action/views.py
@@ -80,7 +80,7 @@ class AdminExportRelated(TemplateView):
         path = request.GET['path']
         field_data = introspection.get_fields(model_class, field_name, path)
         context['related_fields'], model_ct, context['path'] = introspection.get_related_fields(
-            model_class, field_name, path
+            model_class, field_name, path, request.user
         )
         context['model_ct'] = model_ct.id
         context['field_name'] = field_name


### PR DESCRIPTION
Avoid listing relations which the user has no view or change access.
This avoids a bug that occurs when the current user has no access to a related
model but tries to select it on the report. Also, it makes the UI less cluttered.